### PR TITLE
add cleanup and snapshot pruning

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@ $ go test -v -- -u
 
 Any snapshots created/updated will be located in `package/__snapshots__`.
 
+5. Cleanup
+
+To ensure only the snapshots in-use are included, add the following to `TestMain`. If your application does not have one yet, you can read about `TestMain` usage here. [here](https://golang.org/pkg/testing/#hdr-Main).
+
+```go
+func TestMain(m *testing.M) {
+	exit := m.Run()
+	abide.Cleanup()
+	os.Exit(exit)
+}
+```
+
+Once included, if the update `-u` flag is used when running tests, any snapshot that is no longer in use will be removed. If a single test is run, pruning will not occur.
+
 ## Snapshots
 
 A snapshot is essentially a lock file for an http response. Instead of having to manually compare every aspect of an http response to it's expected value, it can be automatically generated and used for matching in subsequent testing.

--- a/args.go
+++ b/args.go
@@ -2,20 +2,30 @@ package abide
 
 import (
 	"os"
+	"strings"
 )
 
 type arguments struct {
 	shouldUpdate bool
+	singleRun    bool
 }
 
 func getArguments() *arguments {
-	shouldUpdate := false
+	args := &arguments{}
 	for _, arg := range os.Args {
-		if arg == "-u" {
-			shouldUpdate = true
+		argList := strings.Split(arg, "=")
+		if len(argList) > 0 {
+			arg = argList[0]
+		}
+		switch arg {
+		case "-u":
+			args.shouldUpdate = true
+			break
+		case "-test.run":
+			args.singleRun = true
 			break
 		}
 	}
 
-	return &arguments{shouldUpdate}
+	return args
 }

--- a/assert.go
+++ b/assert.go
@@ -22,18 +22,21 @@ func Assert(t *testing.T, id string, a Assertable) {
 	data := a.String()
 	snapshot := getSnapshot(snapshotID(id))
 
+	var err error
 	if snapshot == nil {
 		fmt.Printf("Creating snapshot `%s`\n", id)
-		_, err := createSnapshot(snapshotID(id), data)
+		snapshot, err = createSnapshot(snapshotID(id), data)
 		if err != nil {
 			t.Fatal(err)
 		}
+		snapshot.evaluated = true
 		return
 	}
 
+	snapshot.evaluated = true
 	if snapshot != nil && args.shouldUpdate {
 		fmt.Printf("Updating snapshot `%s`\n", id)
-		_, err := createSnapshot(snapshotID(id), data)
+		_, err = createSnapshot(snapshotID(id), data)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -87,13 +90,15 @@ func AssertHTTPResponse(t *testing.T, id string, w *http.Response) {
 
 	if snapshot == nil {
 		fmt.Printf("Creating snapshot `%s`\n", id)
-		_, err = createSnapshot(snapshotID(id), data)
+		snapshot, err = createSnapshot(snapshotID(id), data)
 		if err != nil {
 			t.Fatal(err)
 		}
+		snapshot.evaluated = true
 		return
 	}
 
+	snapshot.evaluated = true
 	diff := compareResults(t, snapshot.value, strings.TrimSpace(data))
 	if diff != "" {
 		if snapshot != nil && args.shouldUpdate {

--- a/example/__snapshots__/example.snapshot
+++ b/example/__snapshots__/example.snapshot
@@ -12,10 +12,6 @@ Content-Type: application/json
   }
 }
 
-/* snapshot: person */
-Foo
-Bar
-
 /* snapshot: second route */
 HTTP/1.1 200 OK
 Connection: close

--- a/example/main_test.go
+++ b/example/main_test.go
@@ -2,10 +2,17 @@ package main
 
 import (
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/beme/abide"
 )
+
+func TestMain(m *testing.M) {
+	exit := m.Run()
+	abide.Cleanup()
+	os.Exit(exit)
+}
 
 func TestFunction(t *testing.T) {
 	req := httptest.NewRequest("GET", "http://example.com/", nil)

--- a/example/models/post_test.go
+++ b/example/models/post_test.go
@@ -1,10 +1,17 @@
 package models
 
 import (
+	"os"
 	"testing"
 
 	"github.com/beme/abide"
 )
+
+func TestMain(m *testing.M) {
+	exit := m.Run()
+	abide.Cleanup()
+	os.Exit(exit)
+}
 
 func TestPost(t *testing.T) {
 	p := &Post{"Foo", "Bar"}


### PR DESCRIPTION
As of now there is no way to get rid of old snapshots without manually removing them. This PR implements pruning. When a developer runs their tests, if they include `-- -u`, in addition to updating any incorrect snapshot, it will also remove any snapshots which were not compared against.

This requires the developer to execute `abide.Cleanup()`. The recommended implementation is to add the cleanup to the `TestMain` code block:

```go
func TestMain(m *testing.M) {
	exit := m.Run()
	abide.Cleanup()
	os.Exit(exit)
}
```

Additionally, if the user runs a single test (`$ go test -v -run SomeTest -- -u`), old snapshots _will not_ be pruned.