### PR TITLE
add AssertReader

### DIFF
--- a/assert.go
+++ b/assert.go
@@ -3,6 +3,8 @@ package abide
 import (
 	"encoding/json"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
 	"strings"
@@ -64,6 +66,15 @@ func AssertHTTPResponse(t *testing.T, id string, w *http.Response) {
 	}
 
 	createOrUpdateSnapshot(t, id, data)
+}
+
+func AssertReader(t *testing.T, id string, r io.Reader) {
+	data, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	createOrUpdateSnapshot(t, id, string(data))
 }
 
 func createOrUpdateSnapshot(t *testing.T, id, data string) {

--- a/assert.go
+++ b/assert.go
@@ -20,36 +20,7 @@ type Assertable interface {
 // Assert asserts the value of an object with implements Assertable.
 func Assert(t *testing.T, id string, a Assertable) {
 	data := a.String()
-	snapshot := getSnapshot(snapshotID(id))
-
-	var err error
-	if snapshot == nil {
-		fmt.Printf("Creating snapshot `%s`\n", id)
-		snapshot, err = createSnapshot(snapshotID(id), data)
-		if err != nil {
-			t.Fatal(err)
-		}
-		snapshot.evaluated = true
-		return
-	}
-
-	snapshot.evaluated = true
-	diff := compareResults(t, snapshot.value, strings.TrimSpace(data))
-	if diff != "" {
-		if snapshot != nil && args.shouldUpdate {
-			fmt.Printf("Updating snapshot `%s`\n", id)
-			_, err = createSnapshot(snapshotID(id), data)
-			if err != nil {
-				t.Fatal(err)
-			}
-			return
-		}
-
-		msg := didNotMatchMessage(diff)
-
-		t.Error(msg)
-		return
-	}
+	createOrUpdateSnapshot(t, id, data)
 }
 
 // AssertHTTPResponse asserts the value of an http.Response.
@@ -58,8 +29,6 @@ func AssertHTTPResponse(t *testing.T, id string, w *http.Response) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	snapshot := getSnapshot(snapshotID(id))
 
 	body, err := httputil.DumpResponse(w, true)
 	if err != nil {
@@ -94,6 +63,13 @@ func AssertHTTPResponse(t *testing.T, id string, w *http.Response) {
 		data = strings.Join(lines, "\n")
 	}
 
+	createOrUpdateSnapshot(t, id, data)
+}
+
+func createOrUpdateSnapshot(t *testing.T, id, data string) {
+	snapshot := getSnapshot(snapshotID(id))
+
+	var err error
 	if snapshot == nil {
 		fmt.Printf("Creating snapshot `%s`\n", id)
 		snapshot, err = createSnapshot(snapshotID(id), data)

--- a/example/__snapshots__/example.snapshot
+++ b/example/__snapshots__/example.snapshot
@@ -12,6 +12,9 @@ Content-Type: application/json
   }
 }
 
+/* snapshot: reader */
+Hello World.
+
 /* snapshot: second route */
 HTTP/1.1 200 OK
 Connection: close

--- a/example/main.go
+++ b/example/main.go
@@ -56,9 +56,14 @@ func thirdHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
+func fourthHandler(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte(`Hello World.`))
+}
+
 func main() {
 	http.HandleFunc("/first", firstHandler)
 	http.HandleFunc("/second", secondHandler)
 	http.HandleFunc("/third", thirdHandler)
+	http.HandleFunc("/fourth", fourthHandler)
 	http.ListenAndServe(":8080", nil)
 }

--- a/example/main_test.go
+++ b/example/main_test.go
@@ -14,7 +14,7 @@ func TestMain(m *testing.M) {
 	os.Exit(exit)
 }
 
-func TestFunction(t *testing.T) {
+func TestRequests(t *testing.T) {
 	req := httptest.NewRequest("GET", "http://example.com/", nil)
 	w := httptest.NewRecorder()
 	firstHandler(w, req)
@@ -32,4 +32,12 @@ func TestFunction(t *testing.T) {
 	thirdHandler(w, req)
 	res = w.Result()
 	abide.AssertHTTPResponse(t, "third route", res)
+}
+
+func TestReader(t *testing.T) {
+	req := httptest.NewRequest("GET", "http://example.com/", nil)
+	w := httptest.NewRecorder()
+	fourthHandler(w, req)
+	res := w.Result()
+	abide.AssertReader(t, "reader", res.Body)
 }


### PR DESCRIPTION
Cleaned up some of the comparison/snapshot-creation logic and added `AssertReader(r io.Reader)`