### PR TITLE
clarify usage of abide.json in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,4 +87,4 @@ In some cases, attributes in a JSON response can by dynamic (e.g unique id's, da
 }
 ```
 
-For any JSON response, the key-value pairs in `defaults` will be used to override, allowing for consistent snapshot testing.
+When used with `AssertHTTPResponse`, for any response with `Content-Type: application/json`, the key-value pairs in `defaults` will be used to override the JSON response, allowing for consistent snapshot testing.


### PR DESCRIPTION
Resolves #30 

This clarifies that `abide.json` is only considered when using `AssertHTTPResponse` with `Content-Type: application/json`. This config and it's usage will evolve over time, but I wanted to make sure it was made clear for now.