### PR TITLE
Better snapshot output and JSON content-type verification

### DIFF
--- a/assert.go
+++ b/assert.go
@@ -39,8 +39,10 @@ func AssertHTTPResponse(t *testing.T, id string, w *http.Response) {
 
 	data := string(body)
 
+	contentType := w.Header.Get("Content-Type")
+
 	// If the response body is JSON, indent.
-	if w.Header.Get("Content-Type") == "application/json" {
+	if contentTypeIsJSON(contentType) {
 		lines := strings.Split(data, "\n")
 		jsonStr := lines[len(lines)-1]
 
@@ -66,6 +68,26 @@ func AssertHTTPResponse(t *testing.T, id string, w *http.Response) {
 	}
 
 	createOrUpdateSnapshot(t, id, data)
+}
+
+func contentTypeIsJSON(contentType string) bool {
+	contentTypeParts := strings.Split(contentType, ";")
+	firstPart := contentTypeParts[0]
+
+	isPlainJSON := firstPart == "application/json"
+	if isPlainJSON {
+		return isPlainJSON
+	}
+
+	isVendor := strings.HasPrefix(firstPart, "application/vnd.")
+
+	isJSON := strings.HasSuffix(firstPart, "+json")
+
+	if isVendor && isJSON {
+		return true
+	}
+
+	return false
 }
 
 // AssertReader asserts the value of an io.Reader.

--- a/assert.go
+++ b/assert.go
@@ -84,7 +84,7 @@ func createOrUpdateSnapshot(t *testing.T, id, data string) {
 	var err error
 	if snapshot == nil {
 		if !args.shouldUpdate {
-			t.Error(newSnapshotMessage(data))
+			t.Error(newSnapshotMessage(id, data))
 			return
 		}
 
@@ -109,7 +109,7 @@ func createOrUpdateSnapshot(t *testing.T, id, data string) {
 			return
 		}
 
-		t.Error(didNotMatchMessage(diff))
+		t.Error(didNotMatchMessage(id, diff))
 		return
 	}
 }
@@ -132,16 +132,18 @@ func compareResults(t *testing.T, existing, new string) string {
 	return dmp.DiffPrettyText(allDiffs)
 }
 
-func didNotMatchMessage(diff string) string {
-	msg := "\n\nExisting snapshot does not match results...\n\n"
+func didNotMatchMessage(id string, diff string) string {
+	msg := "\n\n## Existing snapshot does not match results...\n"
+	msg += "## \"" + id + "\"\n\n"
 	msg += diff
 	msg += "\n\n"
 	msg += "If this change was intentional, run tests again, $ go test -v -- -u\n"
 	return msg
 }
 
-func newSnapshotMessage(body string) string {
-	msg := "\n\nNew snapshot found...\n\n"
+func newSnapshotMessage(id string, body string) string {
+	msg := "\n\n## New snapshot found...\n"
+	msg += "## \"" + id + "\"\n\n"
 	msg += body
 	msg += "\n\n"
 	msg += "To save, run tests again, $ go test -v -- -u\n"

--- a/assert.go
+++ b/assert.go
@@ -83,11 +83,7 @@ func contentTypeIsJSON(contentType string) bool {
 
 	isJSON := strings.HasSuffix(firstPart, "+json")
 
-	if isVendor && isJSON {
-		return true
-	}
-
-	return false
+	return isVendor && isJSON
 }
 
 // AssertReader asserts the value of an io.Reader.
@@ -154,7 +150,7 @@ func compareResults(t *testing.T, existing, new string) string {
 	return dmp.DiffPrettyText(allDiffs)
 }
 
-func didNotMatchMessage(id string, diff string) string {
+func didNotMatchMessage(id, diff string) string {
 	msg := "\n\n## Existing snapshot does not match results...\n"
 	msg += "## \"" + id + "\"\n\n"
 	msg += diff
@@ -163,7 +159,7 @@ func didNotMatchMessage(id string, diff string) string {
 	return msg
 }
 
-func newSnapshotMessage(id string, body string) string {
+func newSnapshotMessage(id, body string) string {
 	msg := "\n\n## New snapshot found...\n"
 	msg += "## \"" + id + "\"\n\n"
 	msg += body

--- a/assert_test.go
+++ b/assert_test.go
@@ -1,31 +1,29 @@
 package abide
 
-import "testing"
-
-var contentTypeTestCases = []struct {
-	input  string
-	output bool
-}{
-	{"application/json", true},
-	{"application/json; charset=utf-8", true},
-	{"application/vnd.foo.bar.v2+json", true},
-	{"application/application/json", false},
-	{"application/json/json", false},
-	{"application/jsoner; charset=utf-8", false},
-	{"application/jsoner", false},
-	{"application/vnd.foo.bar.v2+jsoner", false},
-	{"application/xml", false},
-	{"text/html", false},
-	{"", false},
-}
+import (
+	"testing"
+)
 
 func TestContentTypeIsJSON(test *testing.T) {
-	for _, testCase := range contentTypeTestCases {
+	contentTypeTestCases := map[string]bool{
+		"application/json":                  true,
+		"application/json; charset=utf-8":   true,
+		"application/vnd.foo.bar.v2+json":   true,
+		"application/application/json":      false,
+		"application/json/json":             false,
+		"application/jsoner; charset=utf-8": false,
+		"application/jsoner":                false,
+		"application/vnd.foo.bar.v2+jsoner": false,
+		"application/xml":                   false,
+		"text/html":                         false,
+		"":                                  false,
+	}
 
-		result := contentTypeIsJSON(testCase.input)
+	for input, expectedOutput := range contentTypeTestCases {
+		result := contentTypeIsJSON(input)
 
-		if result != testCase.output {
-			test.Errorf("contentTypeIsJSON(\"%s\" unexpected result. Got=%t, Want=%t", testCase.input, result, testCase.output)
+		if result != expectedOutput {
+			test.Errorf("contentTypeIsJSON(\"%s\" unexpected result. Got=%t, Want=%t", input, result, expectedOutput)
 		}
 	}
 }

--- a/assert_test.go
+++ b/assert_test.go
@@ -1,0 +1,31 @@
+package abide
+
+import "testing"
+
+var contentTypeTestCases = []struct {
+	input  string
+	output bool
+}{
+	{"application/json", true},
+	{"application/json; charset=utf-8", true},
+	{"application/vnd.foo.bar.v2+json", true},
+	{"application/application/json", false},
+	{"application/json/json", false},
+	{"application/jsoner; charset=utf-8", false},
+	{"application/jsoner", false},
+	{"application/vnd.foo.bar.v2+jsoner", false},
+	{"application/xml", false},
+	{"text/html", false},
+	{"", false},
+}
+
+func TestContentTypeIsJSON(test *testing.T) {
+	for _, testCase := range contentTypeTestCases {
+
+		result := contentTypeIsJSON(testCase.input)
+
+		if result != testCase.output {
+			test.Errorf("contentTypeIsJSON(\"%s\" unexpected result. Got=%t, Want=%t", testCase.input, result, testCase.output)
+		}
+	}
+}


### PR DESCRIPTION
When you have a lot of snapshots with similar outputs is a little bit hard to differentiate them.

This commit improves readability by adding the snapshot ID to the output.