### PR TITLE
Assert http requests

### DIFF
--- a/assert.go
+++ b/assert.go
@@ -47,7 +47,7 @@ func AssertHTTPRequestOut(t *testing.T, id string, r *http.Request) {
 	assertHTTP(t, id, body, contentTypeIsJSON(r.Header.Get("Content-Type")))
 }
 
-// AssertHTTPRequestOut asserts the value of an http.Request.
+// AssertHTTPRequest asserts the value of an http.Request.
 // Intended for use when testing incoming client requests
 // See https://golang.org/pkg/net/http/httputil/#DumpRequest for more
 func AssertHTTPRequest(t *testing.T, id string, r *http.Request) {
@@ -59,7 +59,7 @@ func AssertHTTPRequest(t *testing.T, id string, r *http.Request) {
 	assertHTTP(t, id, body, contentTypeIsJSON(r.Header.Get("Content-Type")))
 }
 
-func assertHTTP(t *testing.T, id string, body []byte, isJson bool) {
+func assertHTTP(t *testing.T, id string, body []byte, isJSON bool) {
 	config, err := getConfig()
 	if err != nil {
 		t.Fatal(err)
@@ -68,7 +68,7 @@ func assertHTTP(t *testing.T, id string, body []byte, isJson bool) {
 	data := string(body)
 
 	// If the response body is JSON, indent.
-	if isJson {
+	if isJSON {
 		lines := strings.Split(strings.TrimSpace(data), "\n")
 		jsonStr := lines[len(lines)-1]
 

--- a/assert.go
+++ b/assert.go
@@ -27,22 +27,48 @@ func Assert(t *testing.T, id string, a Assertable) {
 
 // AssertHTTPResponse asserts the value of an http.Response.
 func AssertHTTPResponse(t *testing.T, id string, w *http.Response) {
-	config, err := getConfig()
+	body, err := httputil.DumpResponse(w, true)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	body, err := httputil.DumpResponse(w, true)
+	assertHTTP(t, id, body, contentTypeIsJSON(w.Header.Get("Content-Type")))
+}
+
+// AssertHTTPRequestOut asserts the value of an http.Request.
+// Intended for use when testing outgoing client requests
+// See https://golang.org/pkg/net/http/httputil/#DumpRequestOut for more
+func AssertHTTPRequestOut(t *testing.T, id string, r *http.Request) {
+	body, err := httputil.DumpRequestOut(r, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assertHTTP(t, id, body, contentTypeIsJSON(r.Header.Get("Content-Type")))
+}
+
+// AssertHTTPRequestOut asserts the value of an http.Request.
+// Intended for use when testing incoming client requests
+// See https://golang.org/pkg/net/http/httputil/#DumpRequest for more
+func AssertHTTPRequest(t *testing.T, id string, r *http.Request) {
+	body, err := httputil.DumpRequest(r, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assertHTTP(t, id, body, contentTypeIsJSON(r.Header.Get("Content-Type")))
+}
+
+func assertHTTP(t *testing.T, id string, body []byte, isJson bool) {
+	config, err := getConfig()
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	data := string(body)
 
-	contentType := w.Header.Get("Content-Type")
-
 	// If the response body is JSON, indent.
-	if contentTypeIsJSON(contentType) {
+	if isJson {
 		lines := strings.Split(strings.TrimSpace(data), "\n")
 		jsonStr := lines[len(lines)-1]
 

--- a/example/__snapshots__/example.snapshot
+++ b/example/__snapshots__/example.snapshot
@@ -7,6 +7,30 @@ Content-Type: application/json
   "foo": "foobar"
 }
 
+/* snapshot: http client request */
+GET / HTTP/1.1
+Host: example.com
+User-Agent: Go-http-client/1.1
+Content-Length: 31
+Content-Type: application/json
+X-Expected-Header: expected header value
+Accept-Encoding: gzip
+
+{
+  "message": "expected message"
+}
+
+/* snapshot: http server request */
+POST / HTTP/1.1
+Accept-Encoding: gzip
+Content-Length: 31
+Content-Type: application/json
+User-Agent: Go-http-client/1.1
+
+{
+  "message": "expected message"
+}
+
 /* snapshot: reader */
 Hello World.
 


### PR DESCRIPTION
I found myself needing to test some outgoing client http requests. Imagine a "MockService" and a http client library that has a function like `func (c *client) BuildServiceRequest() *http.Request { ... }`

Anyway. This adds some helpers to make that a little easier.

@sjkaliski What do you think? Useful?