### PR TITLE
Don't create snapshot files with the executable bit set

### DIFF
--- a/abide.go
+++ b/abide.go
@@ -99,7 +99,7 @@ func (s snapshots) save() error {
 			return err
 		}
 
-		err = ioutil.WriteFile(path, data, os.ModePerm)
+		err = ioutil.WriteFile(path, data, 0666)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Previously it would create files with the permissions of 755
(`rwxr-xr-x`), assuming the common umask of 022.

This fixes that so it's 644 (`rw-r--r--`).

Not a huge deal; just looks better in `ls` output etc. :-)