### PR TITLE
Syntactic Sugar. Assertable helpers.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: go
 go:
-  - 1.8.x
   - 1.9.x
   - 1.10.x
   - tip

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 go:
   - 1.9.x
   - 1.10.x
+  - 1.11.x
   - tip
 
 matrix:

--- a/assertables.go
+++ b/assertables.go
@@ -1,0 +1,21 @@
+package abide
+
+import (
+	"fmt"
+)
+
+type assertableString string
+
+func (s assertableString) String() string {
+	return string(s)
+}
+
+// String is syntactic sugar. It is a helper that converts a string to an AssertableString
+func String(s string) assertableString {
+	return assertableString(s)
+}
+
+// Struct is syntactic sugar. It is a helper that converts a struct to an AssertableString using "%+v" formatting.
+func Struct(s interface{}) assertableString {
+	return assertableString(fmt.Sprintf("%+v", s))
+}

--- a/assertables.go
+++ b/assertables.go
@@ -15,7 +15,8 @@ func String(s string) Assertable {
 	return assertableString(s)
 }
 
-// Struct is syntactic sugar. It is a helper that converts a struct to an Assertable.
-func Struct(s interface{}) Assertable {
-	return assertableString(fmt.Sprintf("%+v", s))
+// Interface is syntactic sugar. It is a helper that converts any type to an Assertable.
+func Interface(i interface{}) Assertable {
+	// include the type in the string that is asserted to avoid suprises
+	return assertableString(fmt.Sprintf("%T %+v", i, i))
 }

--- a/assertables.go
+++ b/assertables.go
@@ -10,12 +10,12 @@ func (s assertableString) String() string {
 	return string(s)
 }
 
-// String is syntactic sugar. It is a helper that converts a string to an AssertableString
-func String(s string) assertableString {
+// String is syntactic sugar. It is a helper that converts a string to an Assertable
+func String(s string) Assertable {
 	return assertableString(s)
 }
 
-// Struct is syntactic sugar. It is a helper that converts a struct to an AssertableString using "%+v" formatting.
-func Struct(s interface{}) assertableString {
+// Struct is syntactic sugar. It is a helper that converts a struct to an Assertable.
+func Struct(s interface{}) Assertable {
 	return assertableString(fmt.Sprintf("%+v", s))
 }

--- a/example/__snapshots__/example.snapshot
+++ b/example/__snapshots__/example.snapshot
@@ -1,3 +1,9 @@
+/* snapshot: assertable interface */
+main.MyStruct {Field1:String1 Field2:1234567 Field3:true field4:string4}
+
+/* snapshot: assertable string */
+string to be asserted
+
 /* snapshot: first route */
 HTTP/1.1 200 OK
 Connection: close

--- a/example/main_test.go
+++ b/example/main_test.go
@@ -41,3 +41,23 @@ func TestReader(t *testing.T) {
 	res := w.Result()
 	abide.AssertReader(t, "reader", res.Body)
 }
+
+func TestAssertableString(t *testing.T) {
+	abide.Assert(t, "assertable string", abide.String("string to be asserted"))
+}
+
+func TestAssertableInterface(t *testing.T) {
+	type MyStruct struct {
+		Field1 string
+		Field2 int64
+		Field3 bool
+		field4 string
+	}
+	myStruct := MyStruct{
+		"String1",
+		1234567,
+		true,
+		"string4",
+	}
+	abide.Assert(t, "assertable interface", abide.Interface(myStruct))
+}

--- a/example/main_test.go
+++ b/example/main_test.go
@@ -79,3 +79,4 @@ func TestAssertableInterface(t *testing.T) {
 		"string4",
 	}
 	abide.Assert(t, "assertable interface", abide.Interface(myStruct))
+}

--- a/example_test.go
+++ b/example_test.go
@@ -26,3 +26,24 @@ func ExampleAssertReader() {
 	file, _ := os.Open("/path/to/file")
 	abide.AssertReader(t, "io reader", file)
 }
+
+func ExampleAssertableString() {
+	myString := "this is a string I want to snapshot"
+	abide.Assert(t, "assertable string", abide.String(myString))
+}
+
+func ExampleAssertableStruct() {
+	type MyStruct struct {
+		Field1 string
+		Field2 int64
+		Field3 bool
+		field4 string
+	}
+	myStruct := MyStruct{
+		"String1",
+		1234567,
+		true,
+		"string4",
+	}
+	abide.Assert(t, "assertable struct", abide.Struct(myStruct))
+}

--- a/example_test.go
+++ b/example_test.go
@@ -27,12 +27,12 @@ func ExampleAssertReader() {
 	abide.AssertReader(t, "io reader", file)
 }
 
-func ExampleAssertableString() {
+func ExampleString() {
 	myString := "this is a string I want to snapshot"
 	abide.Assert(t, "assertable string", abide.String(myString))
 }
 
-func ExampleAssertableStruct() {
+func ExampleInterface() {
 	type MyStruct struct {
 		Field1 string
 		Field2 int64

--- a/example_test.go
+++ b/example_test.go
@@ -45,5 +45,5 @@ func ExampleAssertableStruct() {
 		true,
 		"string4",
 	}
-	abide.Assert(t, "assertable struct", abide.Struct(myStruct))
+	abide.Assert(t, "assertable struct", abide.Interface(myStruct))
 }


### PR DESCRIPTION
I found myself re-writing these helpers, and thought it might be a good addition. At the same time, I'm not 100% convinced abide "needs" this... so also OK to keep these helpers out.

`abide.String()` - It is a little frustrating when you want to assert something of type string, and it does not implement `String()`.

`abide.Interface()` - seems slightly less obvious... the main use case being to easily assert the contents of a struct
