### PR TITLE
fix cleanup after update bug and concurrent writes to allSnapshots

### DIFF
--- a/abide.go
+++ b/abide.go
@@ -201,8 +201,18 @@ func getSnapshot(id snapshotID) *snapshot {
 	return allSnapshots[id]
 }
 
-// createSnapshot creates or updates a Snapshot.
+// createSnapshot creates a Snapshot.
 func createSnapshot(id snapshotID, value string) (*snapshot, error) {
+	return writeSnapshot(id, value, false)
+}
+
+// updateSnapshot creates a Snapshot.
+func updateSnapshot(id snapshotID, value string) (*snapshot, error) {
+	return writeSnapshot(id, value, true)
+}
+
+// writeSnapshot creates or updates a Snapshot.
+func writeSnapshot(id snapshotID, value string, isUpdate bool) (*snapshot, error) {
 	if !id.isValid() {
 		return nil, errInvalidSnapshotID
 	}
@@ -227,6 +237,10 @@ func createSnapshot(id snapshotID, value string) (*snapshot, error) {
 		id:    id,
 		value: value,
 		path:  path,
+	}
+
+	if isUpdate {
+		s.evaluated = true
 	}
 
 	allSnapMutex.Lock()

--- a/abide.go
+++ b/abide.go
@@ -234,13 +234,10 @@ func writeSnapshot(id snapshotID, value string, isUpdate bool) (*snapshot, error
 	path := filepath.Join(dir, fmt.Sprintf("%s%s", pkg, snapshotExt))
 
 	s := &snapshot{
-		id:    id,
-		value: value,
-		path:  path,
-	}
-
-	if isUpdate {
-		s.evaluated = true
+		id:        id,
+		value:     value,
+		path:      path,
+		evaluated: isUpdate,
 	}
 
 	allSnapMutex.Lock()

--- a/abide.go
+++ b/abide.go
@@ -14,6 +14,7 @@ import (
 var (
 	args         *arguments
 	allSnapshots snapshots
+	allSnapMutex sync.Mutex
 )
 
 var (
@@ -227,7 +228,10 @@ func createSnapshot(id snapshotID, value string) (*snapshot, error) {
 		value: value,
 		path:  path,
 	}
+
+	allSnapMutex.Lock()
 	allSnapshots[id] = s
+	allSnapMutex.Unlock()
 
 	err = allSnapshots.save()
 	if err != nil {

--- a/abide_test.go
+++ b/abide_test.go
@@ -69,6 +69,38 @@ func TestCleanup(t *testing.T) {
 	}
 }
 
+func TestCleanupUpdate(t *testing.T) {
+	defer testingCleanup()
+
+	_ = testingSnapshot("1", "A")
+	t2 := &testing.T{}
+	createOrUpdateSnapshot(t2, "1", "B")
+
+	snapshot := getSnapshot("1")
+	if snapshot == nil {
+		t.Fatal("Expected snapshot[1] to exist.")
+	}
+
+	// If shouldUpdate = true and singleRun = false, the snapshot must be removed.
+	args.shouldUpdate = true
+	args.singleRun = false
+	err := Cleanup()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// call private reloadSnapshots to repeat once-executing function
+	err = reloadSnapshots()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	snapshot = getSnapshot("1")
+	if snapshot == nil {
+		t.Fatal("Expected snapshot[1] to exist.")
+	}
+}
+
 func TestSnapshotIDIsValid(t *testing.T) {
 	id := snapshotID("1")
 	if !id.isValid() {

--- a/abide_test.go
+++ b/abide_test.go
@@ -72,9 +72,13 @@ func TestCleanup(t *testing.T) {
 func TestCleanupUpdate(t *testing.T) {
 	defer testingCleanup()
 
+	// this snapshot is updated, should be evaluated, and not removed
 	_ = testingSnapshot("1", "A")
 	t2 := &testing.T{}
 	createOrUpdateSnapshot(t2, "1", "B")
+
+	// this snapshot is never evaluated, and should be removed
+	_ = testingSnapshot("2", "B")
 
 	snapshot := getSnapshot("1")
 	if snapshot == nil {
@@ -98,6 +102,10 @@ func TestCleanupUpdate(t *testing.T) {
 	snapshot = getSnapshot("1")
 	if snapshot == nil {
 		t.Fatal("Expected snapshot[1] to exist.")
+	}
+	snapshot = getSnapshot("2")
+	if snapshot != nil {
+		t.Fatal("Expected snapshot[2] to be removed.")
 	}
 }
 

--- a/assert.go
+++ b/assert.go
@@ -160,7 +160,7 @@ func createOrUpdateSnapshot(t *testing.T, id, data string) {
 	if diff != "" {
 		if snapshot != nil && args.shouldUpdate {
 			fmt.Printf("Updating snapshot `%s`\n", id)
-			_, err = createSnapshot(snapshotID(id), data)
+			_, err = updateSnapshot(snapshotID(id), data)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
### Changes
- Add Mutex to protect writes to allSnapshots related to https://github.com/beme/abide/issues/45
- Differentiate update and create snapshot so that `snapshot.evaluated bool` can be correctly set during update.

Prior to this change, cleanup after an update would cause removal of the update ie:
```
=== RUN   TestCleanupUpdate
Updating snapshot `1`
Removing unused snapshot `2`
```

This manifested in a project when running:
`go test -v ./some_package/... -- -u`