### PR TITLE
Feature: Handle binary response body

### DIFF
--- a/assert.go
+++ b/assert.go
@@ -62,7 +62,7 @@ func AssertHTTPResponse(t *testing.T, id string, w *http.Response, opts ...func(
 
 	// keep backward compatibility checking for JSON type when the response type
 	// wasn't provided
-	if options.ContentType == ContentType("") && contentTypeIsJSON(r.Header.Get("Content-Type")) {
+	if options.ContentType == ContentType("") && contentTypeIsJSON(w.Header.Get("Content-Type")) {
 		options.ContentType = ContentTypeJSON
 	}
 	assertHTTP(t, id, body, options.ContentType)

--- a/assert_test.go
+++ b/assert_test.go
@@ -27,29 +27,3 @@ func TestContentTypeIsJSON(test *testing.T) {
 		}
 	}
 }
-
-func TestContentTypeIsBinary(test *testing.T) {
-	contentTypeTestCases := map[string]bool{
-		"application/pdf":                   true,
-		"application/octet-stream":          true,
-		"application/json":                  false,
-		"application/json; charset=utf-8":   false,
-		"application/vnd.foo.bar.v2+json":   false,
-		"application/application/json":      false,
-		"application/json/json":             false,
-		"application/jsoner; charset=utf-8": false,
-		"application/jsoner":                false,
-		"application/vnd.foo.bar.v2+jsoner": false,
-		"application/xml":                   false,
-		"text/html":                         false,
-		"":                                  false,
-	}
-
-	for input, expectedOutput := range contentTypeTestCases {
-		result := contentTypeIsBinary(input)
-
-		if result != expectedOutput {
-			test.Errorf("contentTypeIsBinary(\"%s\" unexpected result. Got=%t, Want=%t", input, result, expectedOutput)
-		}
-	}
-}

--- a/assert_test.go
+++ b/assert_test.go
@@ -27,3 +27,29 @@ func TestContentTypeIsJSON(test *testing.T) {
 		}
 	}
 }
+
+func TestContentTypeIsBinary(test *testing.T) {
+	contentTypeTestCases := map[string]bool{
+		"application/pdf":                   true,
+		"application/octet-stream":          true,
+		"application/json":                  false,
+		"application/json; charset=utf-8":   false,
+		"application/vnd.foo.bar.v2+json":   false,
+		"application/application/json":      false,
+		"application/json/json":             false,
+		"application/jsoner; charset=utf-8": false,
+		"application/jsoner":                false,
+		"application/vnd.foo.bar.v2+jsoner": false,
+		"application/xml":                   false,
+		"text/html":                         false,
+		"":                                  false,
+	}
+
+	for input, expectedOutput := range contentTypeTestCases {
+		result := contentTypeIsBinary(input)
+
+		if result != expectedOutput {
+			test.Errorf("contentTypeIsBinary(\"%s\" unexpected result. Got=%t, Want=%t", input, result, expectedOutput)
+		}
+	}
+}

--- a/example/__snapshots__/example.snapshot
+++ b/example/__snapshots__/example.snapshot
@@ -4,6 +4,9 @@ main.MyStruct {Field1:String1 Field2:1234567 Field3:true field4:string4}
 /* snapshot: assertable string */
 string to be asserted
 
+/* snapshot: fifth route */
+485454502f312e3120323030204f4b0d0a436f6e6e656374696f6e3a20636c6f73650d0a436f6e74656e742d547970653a206170706c69636174696f6e2f7064660d0a0d0a0102030405060708090a
+
 /* snapshot: first route */
 HTTP/1.1 200 OK
 Connection: close

--- a/example/main.go
+++ b/example/main.go
@@ -61,10 +61,16 @@ func fourthHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(`Hello World.`))
 }
 
+func fifthHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/pdf")
+	w.Write([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
+}
+
 func main() {
 	http.HandleFunc("/first", firstHandler)
 	http.HandleFunc("/second", secondHandler)
 	http.HandleFunc("/third", thirdHandler)
 	http.HandleFunc("/fourth", fourthHandler)
+	http.HandleFunc("/fifth", fifthHandler)
 	http.ListenAndServe(":8080", nil)
 }

--- a/example/main_test.go
+++ b/example/main_test.go
@@ -34,6 +34,12 @@ func TestRequests(t *testing.T) {
 	thirdHandler(w, req)
 	res = w.Result()
 	abide.AssertHTTPResponse(t, "third route", res)
+
+	req = httptest.NewRequest("GET", "http://example.com/", nil)
+	w = httptest.NewRecorder()
+	fifthHandler(w, req)
+	res = w.Result()
+	abide.AssertHTTPResponse(t, "fifth route", res)
 }
 
 func TestReader(t *testing.T) {

--- a/example/main_test.go
+++ b/example/main_test.go
@@ -39,7 +39,7 @@ func TestRequests(t *testing.T) {
 	w = httptest.NewRecorder()
 	fifthHandler(w, req)
 	res = w.Result()
-	abide.AssertHTTPResponse(t, "fifth route", res)
+	abide.AssertHTTPResponse(t, "fifth route", res, abide.SetContentType(abide.ContentTypeBinary))
 }
 
 func TestReader(t *testing.T) {


### PR DESCRIPTION
When retrieving a binary response body, convert it to hexadecimal so we can safely add it to the snapshot file.